### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A single-file [MCP](https://modelcontextprotocol.io/) server for [Tautulli](http
 
 11 read-only tools. No mutations. All configuration via environment variables.
 
+[![mcp-tautulli MCP server](https://glama.ai/mcp/servers/lodordev/mcp-tautulli/badges/card.svg)](https://glama.ai/mcp/servers/lodordev/mcp-tautulli)
+
 ## Prerequisites
 
 - Python 3.10+


### PR DESCRIPTION
This PR adds a badge for the [mcp-tautulli](https://glama.ai/mcp/servers/lodordev/mcp-tautulli) server listing in Glama MCP server directory.

[![mcp-tautulli MCP server](https://glama.ai/mcp/servers/lodordev/mcp-tautulli/badges/card.svg)](https://glama.ai/mcp/servers/lodordev/mcp-tautulli)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.